### PR TITLE
🚸 Remove lamindb from noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -84,5 +84,4 @@ def build(session):
 
     # init an instance so that docs can be built
     ln.setup.init(storage="mydata")
-    session.install("lamindb")
     build_docs(session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
     "nbproject",
-    "lamindb>=0.30.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
If not, we need to install `lamin_docs` and manually bump lamindb versions in the toml, otherwise the caches won't update properly, and we'll need to keep deleting caches manually.