### PR TITLE
🚸 Strict docs building

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -144,4 +144,4 @@ def docs(session):
     else:
         session.install(f"{prefix}/lndocs")
     # do not simply add instance creation here
-    session.run("lndocs", "--strip-prefix", "--error-on-index")
+    session.run("lndocs", "--strip-prefix", "--error-on-index", "--strict")

--- a/noxfile.py
+++ b/noxfile.py
@@ -127,10 +127,10 @@ def pull_artifacts(session):
 @nox.session
 def docs(session):
     session.run(*"pip install git+https://github.com/laminlabs/bionty".split())
-    session.run(
-        *"pip install --no-deps git+https://github.com/laminlabs/lnschema-bionty"
-        .split()
-    )
+    # session.run(
+    #     *"pip install --no-deps git+https://github.com/laminlabs/lnschema-bionty"
+    #     .split()
+    # )
     # session.run(*"pip install lnschema_bionty==0.19a5".split())
     # session.run(
     #     *"pip install --no-deps git+https://github.com/laminlabs/lnschema-core".split()  # noqa


### PR DESCRIPTION
We need to switch on strict now to avoid any broken links or missing content.

For instance, if installation fails, we'll not see the API reference.