### PR TITLE
🚧 Switch strict back on and debug with new lndocs

### DIFF
--- a/docs/features-lamindb.md
+++ b/docs/features-lamindb.md
@@ -4,7 +4,7 @@
 - Cache, load & stream artifacts: {class}`~lamindb.Artifact.cache`, {class}`~lamindb.Artifact.load`, {class}`~lamindb.Artifact.backed`
 - Manage {class}`~lamindb.Feature`, {class}`~lamindb.FeatureSet`, {class}`~lamindb.ULabel`
 - Plug-in custom [schemas](/schemas) & manage schema migrations
-- Use array formats in memory & storage: [DataFrame](/tutorial), [AnnData](/data), [MuData](docs:multimodal), [SOMA](docs:cellxgene), ... backed by [parquet](/tutorial), [zarr](/data), [TileDB](docs:cellxgene), [HDF5](/data), [h5ad](/data), [DuckDB](docs:rxrx), ...
+- Use array formats in memory & storage: [DataFrame](/tutorial), [AnnData](/data), [MuData](multimodal), [SOMA](cellxgene), ... backed by [parquet](/tutorial), [zarr](/data), [TileDB](cellxgene), [HDF5](/data), [h5ad](/data), [DuckDB](rxrx), ...
 - Bridge artifacts and warehousing: {class}`~lamindb.Artifact`, {class}`~lamindb.Collection`
 - Leverage out-of-the-box PyTorch data loaders: {meth}`~lamindb.Collection.mapped`
 - Version artifacts, collections & transforms
@@ -12,7 +12,7 @@
 **Track data lineage across notebooks, pipelines & UI: {meth}`~lamindb.track`, {class}`~lamindb.Transform` & {class}`~lamindb.Run`.**
 
 - Execution reports, source code and Python environments for [notebooks & scripts](/track)
-- Integrate with workflow managers: [redun](docs:redun), [nextflow](docs:nextflow), [snakemake](docs:snakemake)
+- Integrate with workflow managers: [redun](redun), [nextflow](nextflow), [snakemake](snakemake)
 
 **Manage registries for experimental metadata & in-house ontologies, import public ontologies.**
 
@@ -39,9 +39,9 @@
   - Currently two SQL backends for managing metadata: SQLite & Postgres
 - Scalable: metadata tables support 100s of millions of entries
 - Auditable: data & metadata records are hashed, timestamped, and attributed to users (soon to come: LaminDB Log)
-- [Access](docs:access) management:
+- [Access](access) management:
   - High-level access management through Lamin's collaborator roles
   - Fine-grained access management via storage & SQL roles (soon to come: Lamin Vault)
-- [Secure](docs:access): embedded in your infrastructure (Lamin has no access to your data & metadata)
+- [Secure](access): embedded in your infrastructure (Lamin has no access to your data & metadata)
 - Tested & typed (up to Django Model fields)
-- [Idempotent](docs:faq/idempotency) & [ACID](docs:faq/acid) operations
+- [Idempotent](faq/idempotency) & [ACID](faq/acid) operations

--- a/docs/features-laminhub.md
+++ b/docs/features-laminhub.md
@@ -9,7 +9,7 @@
 Explore in the hub UI or `lamin load owner/instance` via the CLI:
 
 - [lamin.ai/laminlabs/arrayloader-benchmarks](https://lamin.ai/laminlabs/arrayloader-benchmarks) - Work with ML models & benchmarks
-- [lamin.ai/laminlabs/cellxgene](https://lamin.ai/laminlabs/cellxgene) - An instance with the CELLxGENE data ([guide](docs:cellxgene))
+- [lamin.ai/laminlabs/cellxgene](https://lamin.ai/laminlabs/cellxgene) - An instance with the CELLxGENE data ([guide](cellxgene))
 - [lamin.ai/laminlabs/lamindata](https://lamin.ai/laminlabs/lamindata) - A generic demo instance with various data types
 
 <p style="font-weight: bolder; margin-top: 1rem; margin-bottom: 0.5rem; background: transparent">See validated datasets in context of ontologies & experimental metadata.</p>

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from subprocess import run
@@ -7,6 +8,8 @@ import nox
 from laminci.nox import login_testuser1, run_pre_commit
 
 nox.options.default_venv_backend = "none"
+
+IS_PR = os.getenv("GITHUB_EVENT_NAME") != "push"
 
 
 @nox.session
@@ -218,4 +221,5 @@ def docs(session):
     else:
         session.install(f"{prefix}/lndocs")
     # do not simply add instance creation here
-    session.run("lndocs", "--strip-prefix", "--error-on-index", "--strict")
+    strict = " --strict" if IS_PR else ""
+    session.run(*f"lndocs --strip-prefix --error-on-index{strict}".split())

--- a/noxfile.py
+++ b/noxfile.py
@@ -218,4 +218,4 @@ def docs(session):
     else:
         session.install(f"{prefix}/lndocs")
     # do not simply add instance creation here
-    session.run("lndocs", "--strip-prefix", "--error-on-index")  # "--strict")
+    session.run("lndocs", "--strip-prefix", "--error-on-index", "--strict")

--- a/noxfile.py
+++ b/noxfile.py
@@ -221,5 +221,5 @@ def docs(session):
     else:
         session.install(f"{prefix}/lndocs")
     # do not simply add instance creation here
-    strict = " --strict" if IS_PR else ""
+    strict = " --strict" if not IS_PR else ""
     session.run(*f"lndocs --strip-prefix --error-on-index{strict}".split())


### PR DESCRIPTION
@sunnyosun: Can you prefix markdown intersphinx links with `inv:` in lamin-usecases?

<img width="1146" alt="image" src="https://github.com/laminlabs/lamin-docs/assets/16916678/1e495c5e-cf37-422c-abb2-b4e3f718173a">


For instance: [here](docs:rxrx) now has to become [here](inv:docs:rxrx) as far as I understand the myst docs.
