### PR TITLE
✨ Add workflow_dispatch to build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
   repository_dispatch:
     types: [build]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 8
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"


### PR DESCRIPTION
I got asked to rerun older CIs but instead it would be better if we could just manually dispatch it if necessary.