### PR TITLE
📝 Replace tldr header

### DIFF
--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## TLDR"
+    "## Feature-based annotation"
    ]
   },
   {


### PR DESCRIPTION
I know that we will overhaul that part probably but this triggered me and Niklas/Sophia. It just breaks the style too much.

Either a header like this or something like `in brief`, `in a nutshell`, `in short` or whatever