### PR TITLE
📝 In `laminr` docs, remove references to `install_lamindb()`

### DIFF
--- a/docs/includes/quick-setup-laminr.md
+++ b/docs/includes/quick-setup-laminr.md
@@ -2,7 +2,6 @@ For setup, install the `laminr` and `lamindb` packages and connect to a LaminDB 
 
 ```R
 install.packages("laminr", dependencies = TRUE)  # install the laminr package from CRAN
-laminr::install_lamindb(extra_packages = c("bionty"))  # install lamindb & bionty for use via reticulate
 laminr::lamin_login()  # <-- you can skip this for local & self-hosted instances
 laminr::lamin_connect("<account>/<instance>")  # <-- replace with your instance
 ```

--- a/docs/laminr.md
+++ b/docs/laminr.md
@@ -26,7 +26,7 @@ In addition to `lamindb`'s functionality, `laminr` exposes some functionality of
 - `lamin_login`
 - `lamin_logout`
 - `lamin_save`
-- `install_lamindb`
+- `lamin_settings`
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/setup-laminr.md
+++ b/docs/setup-laminr.md
@@ -63,7 +63,7 @@ For more information about setting the active Python environment see `vignette("
 
 ### Creating a **lamindb** environment
 
-In previous version of **{laminr}** we recommended using the `install_lamindb()` function to create an environment with the correct dependencies.
+In **{laminr}** versions prior to v1.1.0 we recommended using the `install_lamindb()` function to create an environment with the correct dependencies.
 This function has now been deprecated and we recommend using the automatic requirement system instead.
 
 ## Logging in to LaminDB


### PR DESCRIPTION
Fixes #266 