### PR TITLE
🔖 Hub 1.25.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,16 @@
 .. role:: small
 ```
 
+## 2026-04-10 {small}`hub 1.25.0`
+
+- ✨ Card view for sheets [PR](https://github.com/laminlabs/laminhub-public/pull/288) [@chaichontat](https://github.com/chaichontat)
+- ✨ Record page: transform links [PR](https://github.com/laminlabs/laminhub-public/pull/287) [@chaichontat](https://github.com/chaichontat)
+- ✨ Drag-and-drop reordering for sidebar records [PR](https://github.com/laminlabs/laminhub-public/pull/285) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Simplify record creation modal, advocate "Type" also for notes pages [PR](https://github.com/laminlabs/laminhub-public/pull/284) [@falexwolf](https://github.com/falexwolf)
+- 🚸 Move the `ULabels` page under the `Features` tab [PR](https://github.com/laminlabs/laminhub-public/pull/282) [@falexwolf](https://github.com/falexwolf)
+- 🚸 Inline title/description editing [PR](https://github.com/laminlabs/laminhub-public/pull/286) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix display of record type / page descriptions [PR](https://github.com/laminlabs/laminhub-public/pull/283) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-04-08 {small}`hub 1.24.0`
 
 - 🚸 Redesign the run cards and add a tabular view indexed by params and features [PR](https://github.com/laminlabs/laminhub-public/pull/279) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,7 +1,0 @@
-- ✨ Card view for sheets [PR](https://github.com/laminlabs/laminhub-public/pull/288) [@chaichontat](https://github.com/chaichontat)
-- ✨ Record page: transform links [PR](https://github.com/laminlabs/laminhub-public/pull/287) [@chaichontat](https://github.com/chaichontat)
-- ✨ Drag-and-drop reordering for sidebar records [PR](https://github.com/laminlabs/laminhub-public/pull/285) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Simplify record creation modal, advocate "Type" also for notes pages [PR](https://github.com/laminlabs/laminhub-public/pull/284) [@falexwolf](https://github.com/falexwolf)
-- 🚸 Move the `ULabels` page under the `Features` tab [PR](https://github.com/laminlabs/laminhub-public/pull/282) [@falexwolf](https://github.com/falexwolf)
-- 🚸 Inline title/description editing [PR](https://github.com/laminlabs/laminhub-public/pull/286) [@chaichontat](https://github.com/chaichontat)
-- 🐛 Fix display of record type / page descriptions [PR](https://github.com/laminlabs/laminhub-public/pull/283) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.