### PR TITLE
🔖 Hub 1.26.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,12 @@
 .. role:: small
 ```
 
+## 2026-04-12 {small}`hub 1.26.0`
+
+- :bug: Fix space information in new sheet workflow [PR](https://github.com/laminlabs/laminhub-public/pull/291) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix overflow behavior in main navigation tabs [PR](https://github.com/laminlabs/laminhub-public/pull/290) [@chaichontat](https://github.com/chaichontat)
+- 💄 Rename Merge Requests to Change Requests and polish design [PR](https://github.com/laminlabs/laminhub-public/pull/289) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-04-10 {small}`hub 1.25.0`
 
 - ✨ Card view for sheets [PR](https://github.com/laminlabs/laminhub-public/pull/288) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- :bug: Fix space information in new sheet workflow [PR](https://github.com/laminlabs/laminhub-public/pull/291) [@chaichontat](https://github.com/chaichontat)
-- 🐛 Fix overflow behavior in main navigation tabs [PR](https://github.com/laminlabs/laminhub-public/pull/290) [@chaichontat](https://github.com/chaichontat)
-- 💄 Rename Merge Requests to Change Requests and polish design [PR](https://github.com/laminlabs/laminhub-public/pull/289) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.