### PR TITLE
🔖 Hub 1.27.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,13 @@
 .. role:: small
 ```
 
+## 2026-04-16 {small}`hub 1.27.0`
+
+- 🐛 Improve robustness of organization management pages [PR](https://github.com/laminlabs/laminhub-public/pull/295) [@chaichontat](https://github.com/chaichontat)
+- :sparkles: Query records by features [PR](https://github.com/laminlabs/laminhub-public/pull/294) [@chaichontat](https://github.com/chaichontat)
+- :sparkles: Feature-based record linking workflow [PR](https://github.com/laminlabs/laminhub-public/pull/293) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Add the delete action to the records dropdown menu [PR](https://github.com/laminlabs/laminhub-public/pull/292) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-12 {small}`hub 1.26.0`
 
 - 🚸 Rename Merge Requests to Change Requests and polish design [PR](https://github.com/laminlabs/laminhub-public/pull/289) [@keller-mark](https://github.com/keller-mark)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,4 +1,0 @@
-- 🐛 Improve robustness of organization management pages [PR](https://github.com/laminlabs/laminhub-public/pull/295) [@chaichontat](https://github.com/chaichontat)
-- :sparkles: Query records by features [PR](https://github.com/laminlabs/laminhub-public/pull/294) [@chaichontat](https://github.com/chaichontat)
-- :sparkles: Feature-based record linking workflow [PR](https://github.com/laminlabs/laminhub-public/pull/293) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Add the delete action to the records dropdown menu [PR](https://github.com/laminlabs/laminhub-public/pull/292) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.