### PR TITLE
🔖 Hub 1.28.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,12 @@
 .. role:: small
 ```
 
+## 2026-04-19 {small}`hub 1.28.0`
+
+- ⬆️ Upgrade lamindb to 2.4 [PR](https://github.com/laminlabs/laminhub-public/pull/298) [@falexwolf](https://github.com/falexwolf)
+- :zap: Faster sheet saving [PR](https://github.com/laminlabs/laminhub-public/pull/297) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Default sheets to card view [PR](https://github.com/laminlabs/laminhub-public/pull/296) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-16 {small}`hub 1.27.0`
 
 - ✨ Query records by features [PR](https://github.com/laminlabs/laminhub-public/pull/294) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- ⬆️ Upgrade lamindb to 2.4 [PR](https://github.com/laminlabs/laminhub-public/pull/298) [@falexwolf](https://github.com/falexwolf)
-- :zap: Faster sheet saving [PR](https://github.com/laminlabs/laminhub-public/pull/297) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Default sheets to card view [PR](https://github.com/laminlabs/laminhub-public/pull/296) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.