### PR TITLE
🔖 Hub 1.29.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,11 @@
 .. role:: small
 ```
 
+## 2026-04-20 {small}`hub 1.29.0`
+
+- :bug: Fix faceted filter narrowing in projects and reference [PR](https://github.com/laminlabs/laminhub-public/pull/300) [@chaichontat](https://github.com/chaichontat)
+- ✨ Support GitHub-flavored markdown [PR](https://github.com/laminlabs/laminhub-public/pull/299) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-19 {small}`hub 1.28.0`
 
 - 🚸 Default sheets to card view [PR](https://github.com/laminlabs/laminhub-public/pull/296) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :bug: Fix faceted filter narrowing in projects and reference [PR](https://github.com/laminlabs/laminhub-public/pull/300) [@chaichontat](https://github.com/chaichontat)
-- ✨ Support GitHub-flavored markdown [PR](https://github.com/laminlabs/laminhub-public/pull/299) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.