### PR TITLE
🔖 Hub 1.29.2

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,11 @@
 .. role:: small
 ```
 
+## 2026-04-21 {small}`hub 1.29.2`
+
+- :bug: Fix projects page highlighting and pagination [PR](https://github.com/laminlabs/laminhub-public/pull/302) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Sheets: bulk row addition and CSV template download [PR](https://github.com/laminlabs/laminhub-public/pull/301) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-20 {small}`db 2.4.0`
 
 :::{dropdown} ⚠️ Run `lamin migrate deploy`

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :bug: Fix projects page highlighting and pagination [PR](https://github.com/laminlabs/laminhub-public/pull/302) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Sheets: bulk row addition and CSV template download [PR](https://github.com/laminlabs/laminhub-public/pull/301) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.