### PR TITLE
🔖 Hub 1.30.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,13 @@
 .. role:: small
 ```
 
+## 2026-04-25 {small}`hub 1.30.0`
+
+- :children_crossing: Improve sheet keyboard handling [PR](https://github.com/laminlabs/laminhub-public/pull/306) [@chaichontat](https://github.com/chaichontat)
+- ✨ Support the bool `dtype` for CSV upload [PR](https://github.com/laminlabs/laminhub-public/pull/305) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Standardize instance settings and org collab settings [PR](https://github.com/laminlabs/laminhub-public/pull/304) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Canonical run URLs [PR](https://github.com/laminlabs/laminhub-public/pull/303) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-04-24 {small}`nf 0.6.2`
 
 Bugs:

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,4 +1,0 @@
-- :children_crossing: Improve sheet keyboard handling [PR](https://github.com/laminlabs/laminhub-public/pull/306) [@chaichontat](https://github.com/chaichontat)
-- ✨ Support the bool `dtype` for CSV upload [PR](https://github.com/laminlabs/laminhub-public/pull/305) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Standardize instance settings and org collab settings [PR](https://github.com/laminlabs/laminhub-public/pull/304) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Canonical run URLs [PR](https://github.com/laminlabs/laminhub-public/pull/303) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.