### PR TITLE
🔖 Hub 1.30.1

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,12 @@
 .. role:: small
 ```
 
+## 2026-04-27 {small}`hub 1.30.1`
+
+- :bug: Fix audit log rendering [PR](https://github.com/laminlabs/laminhub-public/pull/309) [@chaichontat](https://github.com/chaichontat)
+- :bug: Fix double scroll bars in the transform page [PR](https://github.com/laminlabs/laminhub-public/pull/308) [@chaichontat](https://github.com/chaichontat)
+- :sparkles: Transform link inheritance [PR](https://github.com/laminlabs/laminhub-public/pull/307) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-25 {small}`hub 1.30.0`
 
 - ✨ Support the bool `dtype` for CSV upload [PR](https://github.com/laminlabs/laminhub-public/pull/305) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- :bug: Fix audit log rendering [PR](https://github.com/laminlabs/laminhub-public/pull/309) [@chaichontat](https://github.com/chaichontat)
-- :bug: Fix double scroll bars in the transform page [PR](https://github.com/laminlabs/laminhub-public/pull/308) [@chaichontat](https://github.com/chaichontat)
-- :sparkles: Transform link inheritance [PR](https://github.com/laminlabs/laminhub-public/pull/307) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.