### PR TITLE
🔖 Hub 1.31.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,17 @@
 .. role:: small
 ```
 
+## 2026-05-04 {small}`hub 1.31.0`
+
+- ✨ Add a project detail page [PR](https://github.com/laminlabs/laminhub-public/pull/321) [@falexwolf](https://github.com/falexwolf)
+- 🚸 Launch workflows from records with auto-completed metadata [PR](https://github.com/laminlabs/laminhub-public/pull/320) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Enable ordering and hiding tabs on the instance navbar [PR](https://github.com/laminlabs/laminhub-public/pull/315) [@chaichontat](https://github.com/chaichontat) [@falexwolf](https://github.com/falexwolf)
+- 🚸 Prevent password managers from autocompleting fields [PR](https://github.com/laminlabs/laminhub-public/pull/319) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Support more data types in the feature creation modal [PR](https://github.com/laminlabs/laminhub-public/pull/317) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Show download button for problematic HTMLs [PR](https://github.com/laminlabs/laminhub-public/pull/316) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Add `nf-lamin` plugin detection and alert in launch form [PR](https://github.com/laminlabs/laminhub-public/pull/314) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Enhance Nextflow schema validation and parsing logic [PR](https://github.com/laminlabs/laminhub-public/pull/318) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-04-27 {small}`db 2.4.2`
 
 - 🚸 Support `dtype` URL [PR](https://github.com/laminlabs/lamindb/pull/3664) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,8 +1,0 @@
-- ✨ Add a project detail page [PR](https://github.com/laminlabs/laminhub-public/pull/321) [@falexwolf](https://github.com/falexwolf)
-- 🚸 Launch workflows from records with auto-completed metadata [PR](https://github.com/laminlabs/laminhub-public/pull/320) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Enable ordering and hiding tabs on the instance navbar [PR](https://github.com/laminlabs/laminhub-public/pull/315) [@chaichontat](https://github.com/chaichontat) [@falexwolf](https://github.com/falexwolf)
-- 🚸 Prevent password managers from autocompleting fields [PR](https://github.com/laminlabs/laminhub-public/pull/319) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Support more data types in the feature creation modal [PR](https://github.com/laminlabs/laminhub-public/pull/317) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Show download button for problematic HTMLs [PR](https://github.com/laminlabs/laminhub-public/pull/316) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Add `nf-lamin` plugin detection and alert in launch form [PR](https://github.com/laminlabs/laminhub-public/pull/314) [@chaichontat](https://github.com/chaichontat)
-- 🐛 Enhance Nextflow schema validation and parsing logic [PR](https://github.com/laminlabs/laminhub-public/pull/318) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.