### PR TITLE
🔖 Hub 1.32.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,12 @@
 .. role:: small
 ```
 
+## 2026-05-06 {small}`hub 1.32.0`
+
+- :bug: Fix sorting and pagination in access management pages [PR](https://github.com/laminlabs/laminhub-public/pull/324) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Clean up project detail page [PR](https://github.com/laminlabs/laminhub-public/pull/323) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Experiment page launch improvements [PR](https://github.com/laminlabs/laminhub-public/pull/322) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-05-05 {small}`docs`
 
 - 📝 New guide: Organize datasets [PR](https://github.com/laminlabs/lamindb/pull/3667) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- :bug: Fix sorting and pagination in access management pages [PR](https://github.com/laminlabs/laminhub-public/pull/324) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Clean up project detail page [PR](https://github.com/laminlabs/laminhub-public/pull/323) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Experiment page launch improvements [PR](https://github.com/laminlabs/laminhub-public/pull/322) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.