### PR TITLE
🔖 Hub 1.33.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -14,6 +14,12 @@
 .. role:: small
 ```
 
+## 2026-05-07 {small}`hub 1.33.0`
+
+- :children_crossing: Enforce name requirement for new record dialog [PR](https://github.com/laminlabs/laminhub-public/pull/327) [@chaichontat](https://github.com/chaichontat)
+- :bug: Fix space selector in sheet creation [PR](https://github.com/laminlabs/laminhub-public/pull/326) [@chaichontat](https://github.com/chaichontat)
+- :children_crossing: Clear search on folder navigation in bucket table [PR](https://github.com/laminlabs/laminhub-public/pull/325) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-05-06 {small}`hub 1.32.0`
 
 - 🚸 Clean up project detail page [PR](https://github.com/laminlabs/laminhub-public/pull/323) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- :children_crossing: Enforce name requirement for new record dialog [PR](https://github.com/laminlabs/laminhub-public/pull/327) [@chaichontat](https://github.com/chaichontat)
-- :bug: Fix space selector in sheet creation [PR](https://github.com/laminlabs/laminhub-public/pull/326) [@chaichontat](https://github.com/chaichontat)
-- :children_crossing: Clear search on folder navigation in bucket table [PR](https://github.com/laminlabs/laminhub-public/pull/325) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.