### PR TITLE
🔖 Hub 1.34.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@ Or follow us on social media [LinkedIn](https://linkedin.com/company/lamin-labs)
 .. role:: small
 ```
 
+## 2026-05-10 {small}`hub 1.34.0`
+
+- <img src="https://github.githubassets.com/images/icons/emoji/unicode/2728.png?v8" alt=":sparkles:" width="16" height="16" style="vertical-align:text-bottom;" /> Improve API key management with named keys, expiration date, revocation, etc. [PR](https://github.com/laminlabs/laminhub-public/pull/329) [@Ebad371](https://github.com/Ebad371)
+- <img src="https://github.githubassets.com/images/icons/emoji/unicode/26a1.png?v8" alt=":zap:" width="16" height="16" style="vertical-align:text-bottom;" /> Speed up queries for large databases [PR](https://github.com/laminlabs/laminhub-public/pull/328) [@Koncopd](https://github.com/Koncopd)
+
 ## 2026-05-07 {small}`hub 1.33.0`
 
 - 🚸 Enforce name requirement for new record dialog [PR](https://github.com/laminlabs/laminhub-public/pull/327) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- ✨ Improve API key management with named keys, expiration date, revocation, etc. [PR](https://github.com/laminlabs/laminhub-public/pull/329) [@Ebad371](https://github.com/Ebad371)
-- ⚡️ Speed up queries for large databases [PR](https://github.com/laminlabs/laminhub-public/pull/328) [@Koncopd](https://github.com/Koncopd)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.