### PR TITLE
🔖 Hub 1.35.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-05-11 {small}`hub 1.35.0`
+
+- 💄 Simplify the Records/Labels section of the Overview page [PR](https://github.com/laminlabs/laminhub-public/pull/331) [@falexwolf](https://github.com/falexwolf)
+- 💄 Simpler and more consistent design of the artifact page [PR](https://github.com/laminlabs/laminhub-public/pull/330) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-05-10 {small}`hub 1.34.0`
 
 - ✨ Improve API key management with named keys, expiration date, and revocation [PR](https://github.com/laminlabs/laminhub-public/pull/329) [@Ebad371](https://github.com/Ebad371)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- 💄 Simplify the Records/Labels section of the Overview page [PR](https://github.com/laminlabs/laminhub-public/pull/331) [@falexwolf](https://github.com/falexwolf)
-- 💄 Simpler and more consistent design of the artifact page [PR](https://github.com/laminlabs/laminhub-public/pull/330) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.