### PR TITLE
🔖 Hub 1.35.1

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,10 @@
 .. role:: small
 ```
 
+## 2026-05-11 {small}`hub 1.35.1`
+
+- 💄 Showcase runs on overview page [PR](https://github.com/laminlabs/laminhub-public/pull/332) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-05-11 {small}`hub 1.35.0`
 
 - 💄 Simplify the records/labels section of the overview page [PR](https://github.com/laminlabs/laminhub-public/pull/331) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,1 +1,0 @@
-- 💄 Showcase runs on overview page [PR](https://github.com/laminlabs/laminhub-public/pull/332) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.