### PR TITLE
📝 Blog 2026-05-12

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,10 @@
 .. role:: small
 ```
 
+## 2026-05-12 {small}`blog`
+
+- 📝 Re-engineering the PerturBench benchmarking tasks with data lineage [PR](https://github.com/laminlabs/lamin-blog/pull/36) [@namsaraeva](https://github.com/namsaraeva)
+
 ## 2026-05-11 {small}`hub 1.35.1`
 
 - 💄 Showcase runs on overview page [PR](https://github.com/laminlabs/laminhub-public/pull/332) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/blog.md
+++ b/docs/changelog/soon/blog.md
@@ -1,1 +1,0 @@
-- 📝 Re-engineering the PerturBench benchmarking tasks with data lineage [PR](https://github.com/laminlabs/lamin-blog/pull/36) [@namsaraeva](https://github.com/namsaraeva)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/blog.md to docs/changelog/2026.md and clears the soon file.