### PR TITLE
🔖 Hub 1.35.2

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-05-13 {small}`hub 1.35.2`
+
+- 🐛 Fix typed-record feature filters on sheet-backed records [PR](https://github.com/laminlabs/laminhub-public/pull/335) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix sheet filters for paginated rows [PR](https://github.com/laminlabs/laminhub-public/pull/334) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-05-12 {small}`blog`
 
 - 📝 Re-engineering the PerturBench benchmarking tasks with data lineage [PR](https://github.com/laminlabs/lamin-blog/pull/36) [@ishitajain9717](https://github.com/ishitajain9717) [@namsaraeva](https://github.com/namsaraeva)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :bug: Fix typed-record feature filters on sheet-backed records [PR](https://github.com/laminlabs/laminhub-public/pull/335) [@chaichontat](https://github.com/chaichontat)
-- :bug: Fix sheet filters for paginated rows [PR](https://github.com/laminlabs/laminhub-public/pull/334) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.