### PR TITLE
🔖 Hub 1.37.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-05-26 {small}`hub 1.37.0`
+
+- ✨ Route instance roots to the configured default tab [PR](https://github.com/laminlabs/laminhub-public/pull/337) [@chaichontat](https://github.com/chaichontat)
+- ✨ Run general Python scripts from the `Transforms` tab [PR](https://github.com/laminlabs/laminhub-public/pull/336) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-05-21 {small}`nf 0.8.0`
 
 - 📝 Improve documentation for usage of closures when referring to params [PR](https://github.com/laminlabs/nf-lamin/pull/158) [@rcannood](https://github.com/rcannood)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :sparkles: Route instance roots to the configured default tab [PR](https://github.com/laminlabs/laminhub-public/pull/337) [@chaichontat](https://github.com/chaichontat)
-- ✨ Run general Python scripts from the `Transforms` tab [PR](https://github.com/laminlabs/laminhub-public/pull/336) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.