### PR TITLE
🔖 Hub 1.38.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,12 @@
 .. role:: small
 ```
 
+## 2026-05-31 {small}`hub 1.38.0`
+
+- ⚡️ Speed up frontend queries on large databases by orders of magnitude when `order_by` or `search_in` are not needed [PR](https://github.com/laminlabs/laminhub-public/pull/341) [@Koncopd](https://github.com/Koncopd)
+- 🐛 Fix write-space selection across creation flows [PR](https://github.com/laminlabs/laminhub-public/pull/340) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix record value dtype filter handling [PR](https://github.com/laminlabs/laminhub-public/pull/339) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-05-26 {small}`db 2.5.0`
 
 :::{dropdown} ⚠️ No longer deduplicate existing files when registering them from managed storage locations.

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,3 +1,0 @@
-- :zap: Speed up frontend queries on large databases by orders of magnitude when `order_by` or `search_in` are not needed [PR](https://github.com/laminlabs/laminhub-public/pull/341) [@Koncopd](https://github.com/Koncopd)
-- :bug: Fix write-space selection across creation flows [PR](https://github.com/laminlabs/laminhub-public/pull/340) [@chaichontat](https://github.com/chaichontat)
-- :bug: Fix record value dtype filter handling [PR](https://github.com/laminlabs/laminhub-public/pull/339) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.