### PR TITLE
🔖 Hub 1.39.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,13 @@
 .. role:: small
 ```
 
+## 2026-06-01 {small}`hub 1.39.0`
+
+- ✨ Improve the space selector [PR](https://github.com/laminlabs/laminhub-public/pull/343) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix artifact storage paths after upload and sheet export [PR](https://github.com/laminlabs/laminhub-public/pull/344) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix explicit display fields in selectors [PR](https://github.com/laminlabs/laminhub-public/pull/342) [@chaichontat](https://github.com/chaichontat)
+- :lipstick: Better design for artifacts filter sidebar [PR](https://github.com/laminlabs/laminhub-public/pull/345) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-06-01 {small}`db 2.5.1`
 
 - 🚸 Better organize the logging about query result truncation [PR](https://github.com/laminlabs/lamindb/pull/3701) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,4 +1,0 @@
-- :lipstick: Better design for artifacts filter sidebar [PR](https://github.com/laminlabs/laminhub-public/pull/345) [@falexwolf](https://github.com/falexwolf)
-- :bug: Fix artifact storage paths after upload and sheet export [PR](https://github.com/laminlabs/laminhub-public/pull/344) [@chaichontat](https://github.com/chaichontat)
-- ✨ Improve the space selector [PR](https://github.com/laminlabs/laminhub-public/pull/343) [@chaichontat](https://github.com/chaichontat)
-- :bug: Fix explicit display fields in selectors [PR](https://github.com/laminlabs/laminhub-public/pull/342) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.