### PR TITLE
📝 Blog 2026-06-01

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,10 @@
 .. role:: small
 ```
 
+## 2026-06-01 {small}`blog`
+
+- :recycle: Consistently adopt footnotes for references, drop dedicated references [PR](https://github.com/laminlabs/lamin-blog/pull/50) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-06-01 {small}`hub 1.39.0`
 
 - ✨ Improve the space selector [PR](https://github.com/laminlabs/laminhub-public/pull/343) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/blog.md
+++ b/docs/changelog/soon/blog.md
@@ -1,1 +1,0 @@
-- :recycle: Consistently adopt footnotes for references, drop dedicated references [PR](https://github.com/laminlabs/lamin-blog/pull/50) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/blog.md to docs/changelog/2026.md and clears the soon file.