### PR TITLE
🔖 Hub 1.40.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-06-05 {small}`hub 1.40.0`
+
+- 🚸 Make record creation harder to trigger accidentally [PR](https://github.com/laminlabs/laminhub-public/pull/348) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Prettier display of special transforms & more minimal transform design overall by removing display of unnecessary information [PR](https://github.com/laminlabs/laminhub-public/pull/347) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-06-04 {small}`nf 0.8.2`
 
 - ⚡️ Implement asynchronous artifact creation [PR](https://github.com/laminlabs/nf-lamin/pull/168) [@rcannood](https://github.com/rcannood)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- 🚸 Make record creation harder to trigger accidentally [PR](https://github.com/laminlabs/laminhub-public/pull/348) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Prettier display of special transforms & more minimal transform design overall by removing display of unnecessary information [PR](https://github.com/laminlabs/laminhub-public/pull/347) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.