### PR TITLE
🔖 Hub 1.41.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-06-08 {small}`hub 1.41.0`
+
+- ✨ Add compact density for sheets and record lists [PR](https://github.com/laminlabs/laminhub-public/pull/349) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Add CSV index selection for sheet imports [PR](https://github.com/laminlabs/laminhub-public/pull/350) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-06-05 {small}`hub 1.40.0`
 
 - 🚸 Make record creation harder to trigger accidentally [PR](https://github.com/laminlabs/laminhub-public/pull/348) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- 🚸 Add CSV index selection for sheet imports [PR](https://github.com/laminlabs/laminhub-public/pull/350) [@chaichontat](https://github.com/chaichontat)
-- ✨ Add compact density for sheets and record lists [PR](https://github.com/laminlabs/laminhub-public/pull/349) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.