### PR TITLE
🔖 Hub 1.41.2

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,10 @@
 .. role:: small
 ```
 
+## 2026-06-08 {small}`hub 1.41.2`
+
+- ✨ In transfer, visualize the incoming artifact as a new node and make it clickable to lead to the source database [PR](https://github.com/laminlabs/laminhub-public/pull/351) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-06-08 {small}`db 2.6.0`
 
 :::{dropdown} ⚠️ Run `lamin migrate deploy`

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,1 +1,0 @@
-- ✨ In transfer, visualize the incoming artifact as a new node and make it clickable to lead to the source database [PR](https://github.com/laminlabs/laminhub-public/pull/351) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.