### PR TITLE
🔖 Hub 1.42.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-06-09 {small}`hub 1.42.0`
+
+- ✨ Include collections in the Artifacts list [PR](https://github.com/laminlabs/laminhub-public/pull/353) [@chaichontat](https://github.com/chaichontat)
+- ✨ Include Pro plan on pricing page and a Beta subscription button [PR](https://github.com/laminlabs/laminhub-public/pull/352) [@Ebad371](https://github.com/Ebad371)
+
 ## 2026-06-08 {small}`db 2.6.0`
 
 :::{dropdown} ⚠️ Run `lamin migrate deploy`

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :sparkles: Include collections in the Artifacts list [PR](https://github.com/laminlabs/laminhub-public/pull/353) [@chaichontat](https://github.com/chaichontat)
-- ✨ Include Pro plan on pricing page and a Beta subscription button [PR](https://github.com/laminlabs/laminhub-public/pull/352) [@Ebad371](https://github.com/Ebad371)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.