### PR TITLE
📝 Blog 2026-06-09

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,10 @@
 .. role:: small
 ```
 
+## 2026-06-09 {small}`blog`
+
+- 📝 Simpler queries for the 2.5B transcriptional profiles of the Arc Virtual Cell Atlas [PR](https://github.com/laminlabs/lamin-blog/pull/49) [@falexwolf](https://github.com/falexwolf)
+
 ## 2026-06-09 {small}`hub 1.42.0`
 
 - ✨ Include collections in the Artifacts list [PR](https://github.com/laminlabs/laminhub-public/pull/353) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/blog.md
+++ b/docs/changelog/soon/blog.md
@@ -1,1 +1,0 @@
-- 📝 Simpler queries for the 2.5B transcriptional profiles of the Arc Virtual Cell Atlas [PR](https://github.com/laminlabs/lamin-blog/pull/49) [@falexwolf](https://github.com/falexwolf)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/blog.md to docs/changelog/2026.md and clears the soon file.