### PR TITLE
🔖 Hub 1.43.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,11 @@
 .. role:: small
 ```
 
+## 2026-06-10 {small}`hub 1.43.0`
+
+- ✨ Remember each sheet’s last view [PR](https://github.com/laminlabs/laminhub-public/pull/354) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix recursive data lineage expansion [PR](https://github.com/laminlabs/laminhub-public/pull/355) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-06-10 {small}`db 2.6.1`
 
 - 🚸 Enable passing arbitrary spaces to the `SQLRecordSettings.single_space` setting [PR](https://github.com/laminlabs/lamindb/pull/3727) [@falexwolf](https://github.com/falexwolf)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,2 +1,0 @@
-- :bug: Fix recursive data lineage expansion [PR](https://github.com/laminlabs/laminhub-public/pull/355) [@chaichontat](https://github.com/chaichontat)
-- ✨ Remember each sheet’s last view [PR](https://github.com/laminlabs/laminhub-public/pull/354) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.