### PR TITLE
🔖 Hub 1.44.0

### DIFF
--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -16,6 +16,17 @@
 .. role:: small
 ```
 
+## 2026-06-23 {small}`hub 1.44.0`
+
+- ✨ Add Excel support to sheet imports [PR](https://github.com/laminlabs/laminhub-public/pull/360) [@chaichontat](https://github.com/chaichontat)
+- ✨ Implement schema index feature handling in CSV editor and related components [PR](https://github.com/laminlabs/laminhub-public/pull/356) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Hide sheet index for sheets without a schema index [PR](https://github.com/laminlabs/laminhub-public/pull/362) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Scope sheet import auto-create to writable target spaces [PR](https://github.com/laminlabs/laminhub-public/pull/361) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Add single-space record type controls [PR](https://github.com/laminlabs/laminhub-public/pull/359) [@chaichontat](https://github.com/chaichontat)
+- 🚸 Constrain single-space records to their type space [PR](https://github.com/laminlabs/laminhub-public/pull/357) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Fix XLSX upload failures with worksheet selection [PR](https://github.com/laminlabs/laminhub-public/pull/363) [@chaichontat](https://github.com/chaichontat)
+- 🐛 Prevent list registry selectors from creating missing values [PR](https://github.com/laminlabs/laminhub-public/pull/358) [@chaichontat](https://github.com/chaichontat)
+
 ## 2026-06-10 {small}`hub 1.43.0`
 
 - ✨ Remember each sheet’s last view [PR](https://github.com/laminlabs/laminhub-public/pull/354) [@chaichontat](https://github.com/chaichontat)

--- a/docs/changelog/soon/laminhub-public.md
+++ b/docs/changelog/soon/laminhub-public.md
@@ -1,8 +1,0 @@
-- :bug: Fix XLSX upload failures with worksheet selection [PR](https://github.com/laminlabs/laminhub-public/pull/363) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Hide sheet index for sheets without a schema index [PR](https://github.com/laminlabs/laminhub-public/pull/362) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Scope sheet import auto-create to writable target spaces [PR](https://github.com/laminlabs/laminhub-public/pull/361) [@chaichontat](https://github.com/chaichontat)
-- :sparkles: Add Excel support to sheet imports [PR](https://github.com/laminlabs/laminhub-public/pull/360) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Add single-space record type controls [PR](https://github.com/laminlabs/laminhub-public/pull/359) [@chaichontat](https://github.com/chaichontat)
-- :bug: Prevent list registry selectors from creating missing values [PR](https://github.com/laminlabs/laminhub-public/pull/358) [@chaichontat](https://github.com/chaichontat)
-- 🚸 Constrain single-space records to their type space [PR](https://github.com/laminlabs/laminhub-public/pull/357) [@chaichontat](https://github.com/chaichontat)
-- :sparkles: Implement schema index feature handling in CSV editor and related components [PR](https://github.com/laminlabs/laminhub-public/pull/356) [@chaichontat](https://github.com/chaichontat)


### PR DESCRIPTION
Prepends content from docs/changelog/soon/laminhub-public.md to docs/changelog/2026.md and clears the soon file.